### PR TITLE
[WEB-1457] Add Transform patch to fork to enable Overlays

### DIFF
--- a/src/render/painter.js
+++ b/src/render/painter.js
@@ -404,6 +404,20 @@ class Painter {
             for (this.currentLayer; this.currentLayer < layerIds.length; this.currentLayer++) {
                 const layer = this.style._layers[layerIds[this.currentLayer]];
 
+
+                // <%hack%
+                const sourceOptions = layer.source ? this.style.sourceCaches[layer.source]._source._options : undefined;
+                let visible = true;
+                const transform = sourceOptions && sourceOptions.transform ? sourceOptions.transform : undefined;
+
+                if(transform && transform.enabled) {
+                    visible = this.transform.enableAffineTransform(layer.source);
+                } else {
+                    if (this.transform.disableAffineTransform) this.transform.disableAffineTransform();
+                }
+                // %hack%>
+
+
                 if (layer.source !== (sourceCache && sourceCache.id)) {
                     sourceCache = this.style.sourceCaches[layer.source];
                     coords = [];
@@ -419,7 +433,13 @@ class Painter {
                     coords.reverse();
                 }
 
-                this.renderLayer(this, (sourceCache: any), layer, coords);
+                // <%hack%
+                // mapbox/master:
+                // this.renderLayer(this, (sourceCache: any), layer, coords);
+
+                if (visible) this.renderLayer(this, sourceCache, layer, coords);
+                if (this.transform.disableAffineTransform) this.transform.disableAffineTransform();
+                // %hack%>
             }
         }
 


### PR DESCRIPTION
Moves the some of the patch code from Equinox that allows it transform layers for overlay alignment to mapbox fork. Changes to mapbox's internal API invalidated the way we were maintaining the patch.